### PR TITLE
 [FIX] Remove duplicates from mrp_repair security

### DIFF
--- a/addons/mrp_repair/security/ir.model.access.csv
+++ b/addons/mrp_repair/security/ir.model.access.csv
@@ -5,8 +5,6 @@ access_mrp_repair_line_user,MRP Repair Line user,model_mrp_repair_line,stock.gro
 access_mrp_repair_line_manager,MRP Repair Line manager,model_mrp_repair_line,stock.group_stock_manager,1,1,1,1
 access_mrp_repair_fee_user,MRP Repair Fee user,model_mrp_repair_fee,stock.group_stock_user,1,1,1,1
 access_mrp_repair_fee_manager,MRP Repair Fee manager,model_mrp_repair_fee,stock.group_stock_manager,1,0,0,0
-access_mrp_repair_user,MRP Repair user,model_mrp_repair,stock.group_stock_user,1,1,1,1
-access_mrp_repair_manager,MRP Repair manager,model_mrp_repair,stock.group_stock_manager,1,0,0,0
 access_product_pricelist_manager,product.pricelist manager,product.model_product_pricelist,stock.group_stock_manager,1,0,0,0
 access_product_pricelist_user,product.pricelist user,product.model_product_pricelist,stock.group_stock_user,1,1,1,1
 access_stock_production_lot_user,stock.production.lot user,stock.model_stock_production_lot,stock.group_stock_user,1,1,1,1


### PR DESCRIPTION
User and manager access were overwritten few lines after being set up

Description of the issue/feature this PR addresses:
ID Duplicates in security lines

Current behavior before PR:
Manager has only read access whereas simple user has manager access

Desired behavior after PR is merged:
Manager should have manager access and simple user simple read access



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
